### PR TITLE
PIM-504: PIM | Digital Asset | Downloading Asset Name and file

### DIFF
--- a/src/v1/platforms/AWS/AWS.ts
+++ b/src/v1/platforms/AWS/AWS.ts
@@ -189,7 +189,7 @@ export class AWS implements StoragePlatform {
             Bucket: PIM_DEFAULT_BUCKET,
             Key: options.key,
             VersionId: options.fileId,
-            ResponseContentDisposition: `attachment; filename="${options.key}"`
+            ResponseContentDisposition: `attachment; filename="${options.fileName ?? options.key}"`
         });
         return await getSignedUrl(this.s3Client, command, {
             expiresIn: 3600

--- a/src/v1/platforms/StoragePlatform.ts
+++ b/src/v1/platforms/StoragePlatform.ts
@@ -1,10 +1,11 @@
 import { PassThrough } from 'stream';
 
-export interface DownloadParams {
-    instanceKeyOrOrgUrlOrOrgId: string,
-    fileId: string,
-    key: string
-} 
+export type DownloadParams = {
+    instanceKeyOrOrgUrlOrOrgId: string;
+    fileId: string;
+    fileName: string;
+    key: string;
+};
 
 export interface StoragePlatform {
     readonly [index: string]: any;

--- a/src/v1/routers/fileRouter.ts
+++ b/src/v1/routers/fileRouter.ts
@@ -158,7 +158,7 @@ router.post(
             fileTypes,
             fileNames,
             docIds,
-            numSuperseded,
+            numSuperseded
         } = res.locals);
         const configuredPlatform = res.locals.platformInstance;
 
@@ -198,7 +198,7 @@ router.post(
             // all files were successfully superseded
             logSuccessResponse(resultArray, `[${platform}.SUPERSEDE_FILE]`);
             const finalResult: Record<string, string[]> = {
-                recordArray: resultArray,
+                recordArray: resultArray
             };
             res.locals.result = finalResult;
         }
@@ -253,18 +253,19 @@ router.post(
             orgId: string,
             salesforceUrl: string,
             fileId: string,
+            fileName: string,
             key: string;
-        ({ platform, orgId, salesforceUrl, fileId, key } = res.locals);
+        ({ platform, orgId, salesforceUrl, fileId, fileName, key } =
+            res.locals);
         const configuredPlatform = res.locals.platformInstance;
 
         try {
-            const downloadLink: any = await configuredPlatform.downloadFile!(
-                {
-                    instanceKeyOrOrgUrlOrOrgId: orgId || salesforceUrl,
-                    fileId: fileId,
-                    key: key
-                }
-            );
+            const downloadLink: any = await configuredPlatform.downloadFile!({
+                instanceKeyOrOrgUrlOrOrgId: orgId || salesforceUrl,
+                fileId,
+                key,
+                fileName
+            });
             logSuccessResponse(
                 `downloadLink: ${downloadLink}`,
                 `[${platform}.DOWNLOAD_FILE]`


### PR DESCRIPTION
Previously the files were being downloaded with their AWS ID as their names, now it shows as the name shown on SF
![image](https://user-images.githubusercontent.com/32610179/201482622-8f51645b-47e8-48dd-a7e6-0418718c724d.png)
