### PR TITLE
PIM-926 adding the client Id as a env var

### DIFF
--- a/src/v1/utils/JsForce.ts
+++ b/src/v1/utils/JsForce.ts
@@ -21,7 +21,7 @@ const EXTERNAL_CONTENT_LOCATION = 'E';
 
 export const getSessionId = async (authRequest: PropelAuthRequest) => {
     const session = await jwtSession({
-        clientId: (authRequest.clientId) ? authRequest.clientId : process.env.CLOUD_FILE_STORAGE_CLIENT_ID,
+        clientId: process.env.CLOUD_FILE_STORAGE_CLIENT_ID,
         isTest: authRequest.isTest,
         privateKey: process.env.CLOUD_FILE_STORAGE_KEY,
         user: authRequest.user

--- a/src/v1/utils/JsForce.ts
+++ b/src/v1/utils/JsForce.ts
@@ -21,7 +21,7 @@ const EXTERNAL_CONTENT_LOCATION = 'E';
 
 export const getSessionId = async (authRequest: PropelAuthRequest) => {
     const session = await jwtSession({
-        clientId: authRequest.clientId,
+        clientId: (authRequest.clientId) ? authRequest.clientId : process.env.CLOUD_FILE_STORAGE_CLIENT_ID,
         isTest: authRequest.isTest,
         privateKey: process.env.CLOUD_FILE_STORAGE_KEY,
         user: authRequest.user

--- a/src/v1/utils/JsForce.ts
+++ b/src/v1/utils/JsForce.ts
@@ -21,7 +21,7 @@ const EXTERNAL_CONTENT_LOCATION = 'E';
 
 export const getSessionId = async (authRequest: PropelAuthRequest) => {
     const session = await jwtSession({
-        clientId: process.env.CLOUD_FILE_STORAGE_CLIENT_ID,
+        clientId: (authRequest.clientId) ? authRequest.clientId : process.env.CLOUD_FILE_STORAGE_CLIENT_ID, // TODO remove the clientId check after the security review
         isTest: authRequest.isTest,
         privateKey: process.env.CLOUD_FILE_STORAGE_KEY,
         user: authRequest.user


### PR DESCRIPTION
I've moved the client Id to Heroku as a env var but wanted to leave the ability to pass the client id into the service is for some reason you needed to do that. Maybe we don't need this, thoughts?

Adding the check for clientId back because the code that is packaged for security review is expecting clientId to be passed to Heroku. Will remove the check when we pass security review.