### PR TITLE
MVP-24242: The named credential does not fetch a new access token

### DIFF
--- a/src/v1/utils/JsForce.ts
+++ b/src/v1/utils/JsForce.ts
@@ -51,16 +51,15 @@ export default {
         instanceKey: string
     ) {
         let salesforceUrl: string, sessionId: string, orgNamespace: string; //jsforce
-        ({ salesforceUrl, sessionId, orgNamespace } = await InstanceManager.get(
-            instanceKey,
-            [MapKey.salesforceUrl, MapKey.sessionId, MapKey.orgNamespace]
-        ));
+        ({ salesforceUrl, sessionId } = await InstanceManager.get(instanceKey, [
+            MapKey.salesforceUrl,
+            MapKey.sessionId
+        ]));
         const connection = new jsConnect.Connection({
             instanceUrl: salesforceUrl,
             sessionId
         });
-        orgNamespace = orgNamespace ?? this.setupNamespace(connection);
-
+        orgNamespace = await this.setupNamespace(connection);
         console.log({ tokens, orgNamespace });
 
         const newSetting = {


### PR DESCRIPTION
Fix namespace setup that was causing the token write back to SF to fail