### PR TITLE
MVP-24303 [Hotfix spring22]: Write back to `Cloud_Storage__c` for customers on spring22 and earlier

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node build/v1/main.js PRODUCTION
+web: node build/${VERSION}/main.js PRODUCTION

--- a/src/v0/customTypes/InstanceMap.d.ts
+++ b/src/v0/customTypes/InstanceMap.d.ts
@@ -9,7 +9,7 @@ type FileDetail = {
   frontendBytes: number;
   file?: any;
   uploadStream?: any;
-  mimeType: string;
+  mimeType?: string;
 };
 
 const enum MapKey {

--- a/src/v0/customTypes/environment.d.ts
+++ b/src/v0/customTypes/environment.d.ts
@@ -7,7 +7,7 @@ declare global {
       salesforceUrl: string;
       tenantId: string;
       destinationFolderId: string;
-      CLOUD_FILE_STORAGE_KEY: string;
+      CLOUD_FILE_STORAGE_KEY: string | undefined;
       PLATFORM_CONFIG: string;
     }
   }

--- a/src/v0/customTypes/propel-sfdc-connect.ts
+++ b/src/v0/customTypes/propel-sfdc-connect.ts
@@ -2,7 +2,7 @@ declare module '@propelsoftwaresolutions/propel-sfdc-connect' {
   type PropelAuthRequest = {
     clientId: string;
     isTest: boolean;
-    privateKey: string;
+    privateKey: string | undefined;
     user: string;
   };
 

--- a/src/v0/main.ts
+++ b/src/v0/main.ts
@@ -21,7 +21,7 @@ app.use(express.static(path.join(__dirname, '../../public')));
 
 server.listen(port, () => {
   try {
-    logSuccessResponse(`INIT SUCCESS on port ${port}.`, '[SERVER_INIT]');
+    logSuccessResponse(`V0 INIT SUCCESS on port ${port}.`, '[SERVER_INIT]');
   } catch (err) {
     logErrorResponse(err, '[SERVER_INIT]');
   }

--- a/src/v0/routers/uploadRouter.ts
+++ b/src/v0/routers/uploadRouter.ts
@@ -94,7 +94,7 @@ router.post('/:instanceKey', async (req: any, res: any) => {
             try {
               let fileDetailKey: string = Math.random().toString();
               fileDetailKey = `${fileName}_${fileDetailKey.substring(2)}`;
-              const newFileDetails: FileDetail = {fileName, fileSize, frontendBytes: 0, externalBytes: 0, mimeType};
+              const newFileDetails: FileDetail = {fileName, fileSize, frontendBytes: 0, externalBytes: 0};
 
               ({ fileDetails } = InstanceManager.get(instanceKey, [MapKey.fileDetails]));
               fileDetails = fileDetails ? fileDetails : {} as Record<string, FileDetail> ;

--- a/src/v0/utils/JsForce.ts
+++ b/src/v0/utils/JsForce.ts
@@ -38,7 +38,7 @@ export default {
     ({ connection, orgNamespace } = InstanceManager.get(instanceKey, [MapKey.connection, MapKey.orgNamespace]));
     try {
       const upsertedTokens = await connection
-        .sobject(`${orgNamespace}__Cloud_File_Storage__c`)
+        .sobject(`${orgNamespace}__Cloud_Storage__c`)
         .upsert({ ...(await this.addNamespace(newSetting, instanceKey)) }, 'Name');
 
       logSuccessResponse(upsertedTokens, '[JSFORCE.SEND_TOKENS]');

--- a/src/v0/utils/MessageEmitter.ts
+++ b/src/v0/utils/MessageEmitter.ts
@@ -2,7 +2,8 @@
 
 // Will be used more widely when there are different storages
 const server = require('../main');
-const io = require('socket.io').listen(server);
+import { Server } from 'socket.io';
+const io = new Server(server);
 
 import { logSuccessResponse, logErrorResponse, logProgressResponse } from '../utils/Logger';
 import InstanceManager from '../utils/InstanceManager';

--- a/src/v1/main.ts
+++ b/src/v1/main.ts
@@ -25,7 +25,7 @@ app.use(express.static(path.join(__dirname, '../../public')));
 server.listen(port, async () => {
   try {
     await InstanceManager.connectToRedisServer();
-    logSuccessResponse(`INIT SUCCESS on port ${port}.`, '[SERVER_INIT]');
+    logSuccessResponse(`V1 INIT SUCCESS on port ${port}.`, '[SERVER_INIT]');
   } catch (err) {
     logErrorResponse(err, '[SERVER_INIT]');
   }

--- a/src/v1/platforms/AWS/AWS.ts
+++ b/src/v1/platforms/AWS/AWS.ts
@@ -67,7 +67,7 @@ export class AWS implements StoragePlatform {
         fileDetailKey: string
     ): Promise<any> {
         try {
-            let mimeType: string, orgId: string;
+            let mimeType: string | undefined, orgId: string;
             ({ orgId } = await InstanceManager.get(instanceKey, [
                 MapKey.orgId
             ]));
@@ -151,7 +151,7 @@ export class AWS implements StoragePlatform {
             `File created with key: ${awsFileCreationResult?.Key}`,
             '[AWS.UPLOAD]'
         );
-        if (fileDetails.mimeType.startsWith('video')) {
+        if (fileDetails.mimeType!.startsWith('video')) {
             this.generateAndUploadVideoThumbnail(awsFileCreationResult.Key);
         }
         return createdFileDetails;

--- a/src/v1/platforms/GoogleDrive/GoogleDrive.ts
+++ b/src/v1/platforms/GoogleDrive/GoogleDrive.ts
@@ -114,7 +114,7 @@ export class GoogleDrive implements StoragePlatform {
         fileDetailsMap: Record<string, FileDetail>,
         fileDetailKey: string
     ): Promise<any> {
-        let destinationFolderId: string, fileName: string, mimeType: string;
+        let destinationFolderId: string, fileName: string, mimeType: string | undefined;
         ({ destinationFolderId } = await InstanceManager.get(instanceKey, [
             MapKey.destinationFolderId
         ]));

--- a/src/v1/platforms/StoragePlatform.ts
+++ b/src/v1/platforms/StoragePlatform.ts
@@ -118,7 +118,7 @@ export class CreatedFileDetails {
         public id: string,
         public name: string,
         public webViewLink: string,
-        public fileExtension: string,
+        public fileExtension: string | undefined,
         public platform: PlatformIdentifier
     ) {}
     public webContentLink?: string;

--- a/src/v1/utils/JsForce.ts
+++ b/src/v1/utils/JsForce.ts
@@ -81,7 +81,7 @@ export default {
                 webViewLink: string,
                 id: string,
                 toReplaceId: string,
-                fileExtension: string,
+                fileExtension: string | undefined,
                 fileSize: number | undefined,
                 orgNamespace: string,
                 webContentLink: string | undefined; // newly created file
@@ -112,7 +112,7 @@ export default {
                 orgNamespace ?? (await this.setupNamespace(connection));
 
             let sObjectWithNamespace: string,
-                newAttachment: Record<string, string | number>;
+                newAttachment: Record<string, string | number | undefined>;
             ({
                 name,
                 webViewLink,
@@ -218,7 +218,7 @@ export default {
 
     // UTILS
     addNamespace(
-        customObject: Record<string, string | number>,
+        customObject: Record<string, string | number | undefined>,
         orgNamespace: string
     ) {
         if (!orgNamespace) return customObject;


### PR DESCRIPTION
Really really old customers not only are still using `Cloud_Storage__c`, but are also still pointed to `propel-cloud-doc-management`. 

The changes here do a few things:
1. ensure that v0 keeps track of the code in `propel-cloud-doc-management`
2. ensure that the code change that writes the tokens to `Cloud_Storage__c` is reflected in v0 like in https://github.com/PropelPLM/CloudFileStorage/pull/52
3. make the heroku builds dynamic to reflect the version of the app to build, specified by the `VERSION` config var which should only be either `v0` or `v1`