### PR TITLE
MVP-24663: PDF Files can't be uploaded [Add gfiles works fine] for spring22 and older version

### DIFF
--- a/src/v0/routers/uploadRouter.ts
+++ b/src/v0/routers/uploadRouter.ts
@@ -69,7 +69,7 @@ router.post('/reset/:instanceKey/', async (req: any, res: any) => {
   }
 });
 
-router.post('/:instanceKey', async (req: any, res: any) => {
+router.post('/files/:instanceKey', async (req: any, res: any) => {
   const instanceKey = req.params.instanceKey;
   const form = new Busboy({ headers: req.headers });
   let salesforceUrl: string, isNew: string, fileDetails: Record<string, FileDetail>;


### PR DESCRIPTION
`v0` and `v1` were using different paths for file upload (`/:instanceKey` vs `/files/:instanceKey`). The v0 path has since been updated to the latter to avoid 404s.