### PR TITLE
MVP-24669: Export PDX : Export-App Crashes on exporting change with cloud files

### DIFF
--- a/src/v0/routers/uploadRouter.ts
+++ b/src/v0/routers/uploadRouter.ts
@@ -69,7 +69,7 @@ router.post('/reset/:instanceKey/', async (req: any, res: any) => {
   }
 });
 
-router.post('/:instanceKey', async (req: any, res: any) => {
+router.post('/files/:instanceKey', async (req: any, res: any) => {
   const instanceKey = req.params.instanceKey;
   const form = new Busboy({ headers: req.headers });
   let salesforceUrl: string, isNew: string, fileDetails: Record<string, FileDetail>;

--- a/src/v1/platforms/Office365/Office365.ts
+++ b/src/v1/platforms/Office365/Office365.ts
@@ -17,7 +17,7 @@ import {
 import { PassThrough } from 'stream';
 
 export class Office365 implements StoragePlatform {
-    private constructor() {}
+    private constructor() { }
     private oAuth2Client: CloudStorageProviderClient;
     // private static className: string = 'office365';
 
@@ -239,6 +239,7 @@ export class Office365 implements StoragePlatform {
         if (daDownloadDetailsList.length === 1) {
             const fileObject: Record<string, any> = await this.oAuth2Client
                 .api(
+                    // if we ever NEED PDF formatted downloads. This will break presigned URLs because the microsoft graph api can't do both JEEZ 
                     // `/groups/${groupId}/drive/items/${options?.daDownloadDetailsList?.[0]?.fileId}/content?format=pdf`
                     `/groups/${groupId}/drive/items/${options?.daDownloadDetailsList?.[0]?.fileId}?$select=content.downloadUrl`
                 )
@@ -333,8 +334,8 @@ export class Office365 implements StoragePlatform {
         const user = permissionRes.grantedTo
             ? permissionRes.grantedTo.user
             : permissionRes.grantedToIdentities
-            ? (permissionRes.grantedToIdentities[0] || []).user
-            : {};
+                ? (permissionRes.grantedToIdentities[0] || []).user
+                : {};
 
         /** Get user email addres if creating permission for internal user */
         if (!('email' in user)) {

--- a/src/v1/platforms/Office365/Office365.ts
+++ b/src/v1/platforms/Office365/Office365.ts
@@ -239,9 +239,9 @@ export class Office365 implements StoragePlatform {
         if (daDownloadDetailsList.length === 1) {
             const fileObject: Record<string, any> = await this.oAuth2Client
                 .api(
-                    `/groups/${groupId}/drive/items/${options?.daDownloadDetailsList?.[0]?.fileId}/content?format=pdf`
+                    // `/groups/${groupId}/drive/items/${options?.daDownloadDetailsList?.[0]?.fileId}/content?format=pdf`
+                    `/groups/${groupId}/drive/items/${options?.daDownloadDetailsList?.[0]?.fileId}?$select=content.downloadUrl`
                 )
-                .responseType(ResponseType.RAW)
                 .get();
 
             if (fileObject.status >= 400) {
@@ -252,7 +252,7 @@ export class Office365 implements StoragePlatform {
                 };
             }
 
-            return fileObject.url;
+            return fileObject['@microsoft.graph.downloadUrl'];
         } else {
             throw {
                 code: 500,


### PR DESCRIPTION
Get presigned URL so the export pdx app can directly download files through links that do not require a CORs redirect.