### PR TITLE
PIM-1796: PIM | Digital Assets | DA History is showing a undefined error

### DIFF
--- a/src/v1/utils/JsForce.ts
+++ b/src/v1/utils/JsForce.ts
@@ -164,7 +164,6 @@ export default {
                         ? 'Digital_Asset__c'
                         : `${orgNamespace}Digital_Asset__c`;
                 newAttachment = {
-                    Document_Title__c: name,
                     Content_Location__c: platform,
                     External_File_Id__c: id,
                     Mime_Type__c: fileExtension,
@@ -260,11 +259,12 @@ export default {
         return customObject;
     },
 
-    truncateFileNameToMaxCharacters(
-        fileName: string
-    ) {
+    truncateFileNameToMaxCharacters(fileName: string) {
         if (fileName.length > 75) {
-            return fileName.substring(0, 75).trim() + fileName.substring(fileName.lastIndexOf('.'));
+            return (
+                fileName.substring(0, 75).trim() +
+                fileName.substring(fileName.lastIndexOf('.'))
+            );
         } else {
             return fileName;
         }


### PR DESCRIPTION
Removed `Document_Title__c` field value assignment for PIM as `Digital_Asset__c` SObject does not contain `Document_Title__c`