### PR TITLE
MVP-27356: Replace Document_Title__c with Full_Name__c

### DIFF
--- a/src/v1/platforms/Office365/AuthProvider.ts
+++ b/src/v1/platforms/Office365/AuthProvider.ts
@@ -13,7 +13,7 @@ class AuthProvider implements AuthenticationProvider {
   public async getAccessToken(): Promise<string> {
     try {
       const token = await this.clientCredential.getToken(this.scope);
-      return token ? token.token : null;
+      return token ? token.token : '';
     } catch (err: any) {
       console.log(`Failed to get AccessToken: ${err.message!}`)
       throw err

--- a/src/v1/utils/JsForce.ts
+++ b/src/v1/utils/JsForce.ts
@@ -147,7 +147,7 @@ export default {
                         ? 'Document__c'
                         : `${orgNamespace}Document__c`;
                 newAttachment = {
-                    Full_Name__c: name,
+                    Document_Title__c: name,
                     External_Attachment_URL__c: webViewLink,
                     File_Extension__c: fileExtension,
                     Google_File_Id__c: id,

--- a/src/v1/utils/JsForce.ts
+++ b/src/v1/utils/JsForce.ts
@@ -147,7 +147,7 @@ export default {
                         ? 'Document__c'
                         : `${orgNamespace}Document__c`;
                 newAttachment = {
-                    Document_Title__c: name,
+                    Full_Name__c: name,
                     External_Attachment_URL__c: webViewLink,
                     File_Extension__c: fileExtension,
                     Google_File_Id__c: id,


### PR DESCRIPTION
Original implementation used Document_Title__c, but redo functionality utilizes new Full_Name__c field